### PR TITLE
Testing that this module returns undef on server errors

### DIFF
--- a/t/errors.t
+++ b/t/errors.t
@@ -1,0 +1,44 @@
+#!/usr/bin/perl
+
+use Modern::Perl;
+use Test::More;
+
+use Cache::Memcached::Fast;
+
+## IN THIS FILE ##
+#
+# Trigger errors when the memcached server is not available.
+# -When actions are performed correctly, True is returned
+# -When actions failed, but not errored, False is returned
+# -When actions fail due to errors, undef is returned
+
+
+#Create a bad server handle
+my $memd = new Cache::Memcached::Fast({
+    servers   => [ '127.0.0.1:22122' ], #This must be a nonexistent service
+    namespace => 'bad:',
+    utf8      => 1,
+});
+
+# Get server versions.
+
+
+
+subtest "Memcached is unreachable, so operations return undef", sub {
+
+    my $rv;
+
+    $rv = $memd->server_versions;
+    is(ref($rv), 'HASH', "server_versions() still returns a HASH");
+    my @versionKeys = keys %$rv;
+    ok(not(@versionKeys), "No versions found");
+
+    $rv = $memd->add('key', 'text');
+    ok(not(defined($rv)), "add()");
+
+    $rv = $memd->get('key');
+    ok(not(defined($rv)), "get()");
+
+};
+
+done_testing();


### PR DESCRIPTION
Hi!

I was testing some interfacing issues with our Koha ILS and Cache::Memcached::Fast and I was suspecting this module didn't always return undef on memcached server errors/exceptions.

Luckily this module works all fine, but I went and added some test while finding the culprit.
Sharing them in case they might be useful.
