### PR TITLE
Strip -flto from CFLAGS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,13 @@ WriteMakefile(
     },
 );
 
+sub MY::cflags {
+  my $self = shift;
+  my $orig = $self->MM::cflags(@_);
+  $orig =~ s/-flto\b//g;
+  return $orig;
+}
+
 sub MY::postamble {
 '
 $(MYEXTLIB): src/Makefile


### PR DESCRIPTION
-flto breaks compilation of static archives and needs significant  magic
to not break, including sentience about which CC you're using.

See also https://github.com/DCIT/perl-CryptX/issues/32 for where I had a similar issue, but fixed it differently while Not entirely sure wtf I'm doing with EUMM.