### PR TITLE
Fix stack when not returning anything

### DIFF
--- a/Fast.xs
+++ b/Fast.xs
@@ -800,6 +800,7 @@ set(memd, ...)
                 PUSHs(*val);
                 XSRETURN(1);
               }
+            XSRETURN_EMPTY;
           }
 
 
@@ -941,6 +942,7 @@ get(memd, ...)
             PUSHs(sv_2mortal(value_res.vals));
             XSRETURN(1);
           }
+        XSRETURN_EMPTY;
 
 
 void
@@ -1025,6 +1027,7 @@ incr(memd, ...)
                 PUSHs(*val);
                 XSRETURN(1);
               }
+            XSRETURN_EMPTY;
           }
 
 
@@ -1155,6 +1158,7 @@ delete(memd, ...)
                 PUSHs(*val);
                 XSRETURN(1);
               }
+            XSRETURN_EMPTY;
           }
 
 
@@ -1285,6 +1289,7 @@ touch(memd, ...)
                 PUSHs(*val);
                 XSRETURN(1);
               }
+            XSRETURN_EMPTY;
           }
 
 


### PR DESCRIPTION
Some XS api functions omitted stack updates when they were not going to return anything. This is incorrect for PPCODE-based subs - unlike CODE subs, where ParseXS takes care of the stack, they're responsible to clean up the stack. When such sub just return's, without stack adjustments, it effectively returns the same arguments that had been passed to it.

For example, the get() sub in case of an error would've returned memd object instead of undef, wrongly indicating success.