### PR TITLE
fix #18

### DIFF
--- a/Fast.xs
+++ b/Fast.xs
@@ -1043,7 +1043,8 @@ gat_multi(memd, ...)
         value_res.memd = memd;
         value_res.vals = (SV *) newAV();
         sv_2mortal(value_res.vals);
-        av_extend((AV *) value_res.vals, key_count - 1);
+        if (key_count > 1)
+          av_extend((AV *) value_res.vals, key_count - 1);
         client_reset(memd->c, &object, 0);
         sv = ST(1);
         SvGETMAGIC(sv);

--- a/lib/Cache/Memcached/Fast.pm
+++ b/lib/Cache/Memcached/Fast.pm
@@ -1234,7 +1234,7 @@ B<gat> command first appeared in B<memcached> 1.5.3.
 
 =item C<gats>
 
-  $memd->gets($expiration_time, $key);
+  $memd->gats($expiration_time, $key);
 
 Update the expiration time and Retrieve the value and its CAS for a I<$key>.
 


### PR DESCRIPTION
I was developing on an older version and didn't notice the problem.
Improved checking of av_extend.

```
$ perl -v

This is perl 5, version 32, subversion 0 (v5.32.0) built for x86_64-linux
(snip)
$ prove -bl t/commands.t
t/commands.t .. ok
All tests successful.
Files=1, Tests=126, 21 wallclock secs ( 0.03 usr  0.01 sys +  0.10 cusr  0.03 csys =  0.17 CPU)
Result: PASS
```