### PR TITLE
add make deps

### DIFF
--- a/src/Makefile.PL
+++ b/src/Makefile.PL
@@ -58,6 +58,8 @@ libclient$(LIB_EXT): $(OBJECT)
 	$(AR) cr libclient$(LIB_EXT) $(OBJECT)
 	$(RANLIB) libclient$(LIB_EXT)
 
+$(OBJECT): compute_crc32.h parse_keyword.h
+
 parse_keyword.c parse_keyword.h :: genparser.pl reply.kw
 	$(PERL) genparser.pl reply.kw parse_keyword.c parse_keyword.h
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Cache-Memcached-Fast.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcache-memcached-fast-perl/raw/master/debian/patches/add-make-deps.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
